### PR TITLE
fix Homepage link on pypi.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email='ew2789@gmail.com',
     packages=find_packages(),
     include_package_data=True,
-    url='http://github/erikvw/django-revision',
+    url='https://github.com/erikvw/django-revision',
     license='GPL license, see LICENSE',
     description='Track the git revision with every model instance saved.',
     long_description=README,


### PR DESCRIPTION
The "Homepage" link on pypi.org currently fails to load because "github" (without .com) cannot be resolved. This replaces the broken URL with the real one, fixing the link on pypi.org.

https://pypi.org/project/django-revision/